### PR TITLE
Sort by rating, delete ratings task

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -77,6 +77,8 @@ function addEvent(event) {
                     console.log(err2);
                     resolve();
                 }
+            } else {
+                resolve();
             }
         });
     });

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -676,35 +676,35 @@ function getAllNpmModules(from) {
 }
 
 function pruneRatings() {
-    return ratings.getRatedModules().then(function(ratedModules) {
+    return ratings.getRatedModules().then(function (ratedModules) {
         var promises = [];
         ratedModules.forEach(function (name) {
             promises.push(
-                npmNodes.get(name).then(function(node) {
+                npmNodes.get(name).then(function (node) {
                     return null;
                 }).otherwise(function (err) {
                     if (err.message.startsWith('node not found:')) {
                         return ratings.removeForModule(name).then(function () {
-                          return events.add({
-                              "action": "remove_ratings",
-                              "module": name,
-                              "message": "ratings removed"
-                          });
+                            return events.add({
+                                "action": "remove_ratings",
+                                "module": name,
+                                "message": "ratings removed"
+                            });
                         }).then(function () {
-                          return name+' ratings removed';
+                            return name + ' ratings removed';
                         });
                     } else {
                         throw err;
                     }
                 }));
         });
-        return when.settle(promises).then(function(results) {
-          return results.filter(function(res) {
-            return res.state == 'rejected' || res.value;
-          });
+        return when.settle(promises).then(function (results) {
+            return results.filter(function (res) {
+                return res.state == 'rejected' || res.value;
+            });
         })
     });
-  }
+}
   
 
 module.exports = {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -14,6 +14,7 @@ var Twitter = require('twitter');
 
 var npmNodes = require('./nodes');
 var events = require('./events');
+var ratings = require('./ratings');
 
 var twitterClient = new Twitter(settings.twitter);
 
@@ -674,6 +675,38 @@ function getAllNpmModules(from) {
     });
 }
 
+function pruneRatings() {
+    return ratings.getRatedModules().then(function(ratedModules) {
+        var promises = [];
+        ratedModules.forEach(function (name) {
+            promises.push(
+                npmNodes.get(name).then(function(node) {
+                    return null;
+                }).otherwise(function (err) {
+                    if (err.message.startsWith('node not found:')) {
+                        return ratings.removeForModule(name).then(function () {
+                          return events.add({
+                              "action": "remove_ratings",
+                              "module": name,
+                              "message": "ratings removed"
+                          });
+                        }).then(function () {
+                          return name+' ratings removed';
+                        });
+                    } else {
+                        throw err;
+                    }
+                }));
+        });
+        return when.settle(promises).then(function(results) {
+          return results.filter(function(res) {
+            return res.state == 'rejected' || res.value;
+          });
+        })
+    });
+  }
+  
+
 module.exports = {
     refreshAll: function() {
         return refreshUpdatedSince(0);
@@ -686,5 +719,6 @@ module.exports = {
     getUpdatedModules: getUpdatedModules,
     getLatestVersion:getLatestVersion,
     pruneRemoved: pruneRemoved,
-    getAllNpmModules: getAllNpmModules
+    getAllNpmModules: getAllNpmModules,
+    pruneRatings: pruneRatings
 }

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -484,7 +484,6 @@ function processUpdated(list) {
         var name = item.name;
         promises.push(
             npmNodes.get(name).then(function(prevInfo) {
-                var rating = prevInfo.rating;
                 var lastUpdateTime = (new Date(prevInfo.updated_at)).getTime();
                 return getLatestVersion(name).then(function(info) {
                     // copy over previous rating

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -483,38 +483,42 @@ function processUpdated(list) {
     list.forEach(function(item) {
         var name = item.name;
         promises.push(
-            npmNodes.getLastUpdateTime(name).then(function(lastUpdateTime) {
-                return getLatestVersion(name)
-                    .then(function(info) {
-                        return npmNodes.save(info).then(function(saveResponse) {
-                            if (info) {
-                                events.add({
-                                    "action": "update",
-                                    "module": info.name,
-                                    "version": info['dist-tags'].latest
-                                });
-                                try {
-                                    if (Date.parse(info.time.modified)-lastUpdateTime > 1000*60*60*2) {
-                                        tweet(info);
-                                    } else {
-                                        console.log(name,": not tweeting ("+(Date.parse(info.time.modified)-lastUpdateTime)+")")
-                                    }
-                                } catch(err) {
-                                    console.log(name,": error deciding whether to tweet:",err.stack)
+            npmNodes.get(name).then(function(prevInfo) {
+                var rating = prevInfo.rating;
+                var lastUpdateTime = (new Date(prevInfo.updated_at)).getTime();
+                return getLatestVersion(name).then(function(info) {
+                    // copy over previous rating
+                    if (info && prevInfo.rating) {
+                        info.rating = prevInfo.rating;
+                    }
+                    return npmNodes.save(info).then(function(saveResponse) {
+                        if (info) {
+                            events.add({
+                                "action": "update",
+                                "module": info.name,
+                                "version": info['dist-tags'].latest
+                            });
+                            try {
+                                if (Date.parse(info.time.modified)-lastUpdateTime > 1000*60*60*2) {
+                                    tweet(info);
+                                } else {
+                                    console.log(name,": not tweeting ("+(Date.parse(info.time.modified)-lastUpdateTime)+")")
                                 }
+                            } catch(err) {
+                                console.log(name,": error deciding whether to tweet:",err.stack)
                             }
-                            return saveResponse;
-                        })
-                    })
-                    .otherwise(function(err) {
-                        return npmNodes.remove(name).then(function() {
-                            console.log("Removed",name,err);
-                            console.log(err.stack);
-                        }).otherwise(function(err2) {
-                            console.log("Remove failed",name,err2);
-                        })
-                    })
-                })
+                        }
+                        return saveResponse;
+                    });
+                }).otherwise(function(err) {
+                    return npmNodes.remove(name).then(function() {
+                        console.log("Removed",name,err);
+                        console.log(err.stack);
+                    }).otherwise(function(err2) {
+                        console.log("Remove failed",name,err2);
+                    });
+                });
+            })
         );
     });
     return when.settle(promises).then(function(results) {

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -96,6 +96,30 @@ function getForUser(npmModule, user) {
     });
 }
 
+function removeForModule(npmModule) {
+    return when.promise(function (resolve, reject) {
+        db.ratings.remove({ module: npmModule }, function (err) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(npmModule + ' ratings deleted');
+        });
+    });
+}
+
+function getRatedModules() {
+    return when.promise(function (resolve, reject) {
+        db.ratings.distinct("module", {}, function (err, ratedModules) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(ratedModules);
+        });
+    });
+}
+
 module.exports = {
     save: saveRating,
     remove: removeRating,
@@ -115,5 +139,7 @@ module.exports = {
             }
             return rating;
         });
-    }
+    },
+    getRatedModules: getRatedModules,
+    removeForModule: removeForModule
 }

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -39,7 +39,7 @@ function removeRating(rating) {
                 resolve();
             }
         });
-    })
+    });
 }
 
 function getModuleRating(npmModule) {
@@ -73,7 +73,7 @@ function getModuleRating(npmModule) {
 
 function getForUser(npmModule, user) {
     return when.promise(function (resolve, reject) {
-        db.ratings.find({
+        db.ratings.findOne({
             user: user,
             module: npmModule
         }, function (err, results) {
@@ -87,8 +87,8 @@ function getForUser(npmModule, user) {
                 var userRating = {
                     rating: 0
                 };
-                if (results.length > 0) {
-                    userRating = results[0];
+                if (results) {
+                    userRating = results;
                 }
                 resolve(userRating);
             }

--- a/lib/view.js
+++ b/lib/view.js
@@ -16,7 +16,8 @@ var defaultProjection = {
     _rev:1,
     "dist-tags.latest":1,
     official:1,
-    downloads:1
+    downloads:1,
+    rating:1
 };
 var summaryProjection = {
     _id: 1,

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
     "name": "node-red-flows",
     "version": "0.1.0",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "mocha test/**/*_spec.js",
         "start": "node app.js",
         "nodemon": "nodemon --inspect=0.0.0.0:5858 --ignore data/ ./app.js",
         "dev": "npm run nodemon",
         "docker": "docker-compose -f docker-compose.yml up --build"
     },
     "dependencies": {
-        "acorn":"5.2.1",
+        "acorn": "5.2.1",
         "body-parser": "1.18.2",
         "connect-mongo": "2.0.0",
         "cookie-parser": "1.4.3",
         "csurf": "1.9.0",
-        "express-session":"1.15.6",
+        "express-session": "1.15.6",
         "express": "4.x",
         "fs-extra": "4.0.2",
         "marked": "*",
@@ -22,12 +22,15 @@
         "mustache": "*",
         "oauth": "0.9.15",
         "request": "2.83.0",
-        "serve-static":"1.13.1",
+        "serve-static": "1.13.1",
         "tar": "1.0.3",
         "twitter": "1.2.5",
         "when": "3.7.x"
     },
     "devDependencies": {
-        "nodemon": "^1.12.1"
+        "nodemon": "^1.12.1",
+        "mocha": "4.1.0",
+        "should": "13.2.1",
+        "sinon": "4.1.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "node-red-flows",
     "version": "0.1.0",
     "scripts": {
-        "test": "mocha test/**/*_spec.js",
+        "test": "mocha test/**/*_spec.js --exit",
         "start": "node app.js",
         "nodemon": "nodemon --inspect=0.0.0.0:5858 --ignore data/ ./app.js",
         "dev": "npm run nodemon",

--- a/public/css/library.css
+++ b/public/css/library.css
@@ -528,6 +528,8 @@ p.flow-install code {
     display:inline-block;
     vertical-align:top;
     margin-left: 30px;
+    margin-top: -12px;
+    line-height: 1.5;
 }
 
 .gistbox-sort-option {
@@ -584,7 +586,7 @@ li.gistbox {
     background: #fff;
     float: left;
     width: 31%;
-    min-width: 200px;
+    min-width: 240px;
     height: 125px;
     margin-bottom: 15px;
     margin-right: 15px;
@@ -673,7 +675,7 @@ a:hover .gistbox-footer {
     list-style-type: none;
     font-size: 14px;
     padding: 0;
-    margin: 0;
+    margin: 5px 0;
     display: inline-block;
     vertical-align: middle;
 }
@@ -878,6 +880,7 @@ a:hover .gistbox-footer {
 @media handheld, only screen and (max-width: 900px) {
     .gist-sort {
         margin-left:0;
+        margin-top:0;
         display: block;
     }
     .gist-sort div {

--- a/routes/nodes.js
+++ b/routes/nodes.js
@@ -202,6 +202,14 @@ app.post("/node/:scope(@[^\\/]{1,})?/:id([^@][^\\/]{1,})/rate", csrfProtection,f
                 rating.version = version;
                 return ratings.save(rating);
             }).then(function() {
+                return ratings.get(id);
+            }).then(function(rating) {
+                var nodeRating = {
+                    score: rating.total/rating.count,
+                    count: rating.count
+                }
+                return npmNodes.update(id,{rating: nodeRating});
+            }).then(function() {
                 return events.add({
                     action:"module_rating",
                     module: id,

--- a/tasks/prune-ratings.js
+++ b/tasks/prune-ratings.js
@@ -1,48 +1,14 @@
 var when = require("when");
 var settings = require("../config");
-var ratings = require("../lib/ratings");
+var modules = require("../lib/modules");
 var npmNodes = require("../lib/nodes");
-var events = require("../lib/events");
 
-// prune ratings for nodes that are no longer in our database
-function pruneRatings() {
-  return ratings.getRatedModules().then(function(ratedModules) {
-      var promises = [];
-      ratedModules.forEach(function (name) {
-          promises.push(
-              npmNodes.get(name).then(function(node) {
-                  return null;
-              }).otherwise(function (err) {
-                  if (err.message.startsWith('node not found:')) {
-                      return ratings.removeForModule(name).then(function () {
-                        return events.add({
-                            "action": "remove_ratings",
-                            "module": name,
-                            "message": "ratings removed"
-                        });
-                      }).then(function () {
-                        return name+' ratings removed';
-                      });
-                  } else {
-                      throw err;
-                  }
-              }));
-      });
-      // return rejected and removed ratings
-      return when.settle(promises).then(function(results) {
-        return results.filter(function(res) {
-          return res.state == 'rejected' || res.value;
-        });
-      })
-  });
-}
-
-pruneRatings().then(function(results) {
+modules.pruneRatings().then(function(results) {
     results.forEach(function(res) {
         if (res.state === 'rejected') {
-            console.log("Failed:",res.reason);
+            console.log("Failed: ",res.reason);
         } else if (res.value) {
-            console.log(res.value);
+            console.log("Updated: "+res.value);
         }
     });
 

--- a/tasks/prune-ratings.js
+++ b/tasks/prune-ratings.js
@@ -1,0 +1,50 @@
+var when = require("when");
+var settings = require("../config");
+var ratings = require("../lib/ratings");
+var npmNodes = require("../lib/nodes");
+var events = require("../lib/events");
+
+// prune ratings for nodes that are no longer in our database
+function pruneRatings() {
+  return ratings.getRatedModules().then(function(ratedModules) {
+      var promises = [];
+      ratedModules.forEach(function (name) {
+          promises.push(
+              npmNodes.get(name).then(function(node) {
+                  return null;
+              }).otherwise(function (err) {
+                  if (err.message.startsWith('node not found:')) {
+                      return ratings.removeForModule(name).then(function () {
+                        return events.add({
+                            "action": "remove_ratings",
+                            "module": name,
+                            "message": "ratings removed"
+                        });
+                      }).then(function () {
+                        return name+' ratings removed';
+                      });
+                  } else {
+                      throw err;
+                  }
+              }));
+      });
+      // return rejected and removed ratings
+      return when.settle(promises).then(function(results) {
+        return results.filter(function(res) {
+          return res.state == 'rejected' || res.value;
+        });
+      })
+  });
+}
+
+pruneRatings().then(function(results) {
+    results.forEach(function(res) {
+        if (res.state === 'rejected') {
+            console.log("Failed:",res.reason);
+        } else if (res.value) {
+            console.log(res.value);
+        }
+    });
+
+    npmNodes.close();
+});

--- a/template/_gistlist.html
+++ b/template/_gistlist.html
@@ -77,6 +77,10 @@ function sortByRating() {
     var list = $("ul.gistlist");
     list.children().detach();
     items.sort(function(A,B) {
+        B.score = B.score || 0;
+        A.score = A.score || 0;
+        B.count = B.count || 0;
+        A.count = A.count || 0;
         if (B.score!=A.score){
             return (B.score-A.score);
         } else {

--- a/template/_gistlist.html
+++ b/template/_gistlist.html
@@ -11,9 +11,10 @@
         </div>
         <div class="gist-sort">
             <span>Sort by:</span>
-            <span style="display: inline-block; vertical-align: top">
+            <span>
                 <div><input class="gistbox-sort-option" id="gistbox-sort-option-recent" checked type="radio" name="sort-option" value="recent"> <label class="gistbox-sort-label" for="gistbox-sort-option-recent">recent</label></div>
                 <div><input class="gistbox-sort-option" id="gistbox-sort-option-downloads" type="radio" name="sort-option" value="downloads"> <label class="gistbox-sort-label" for="gistbox-sort-option-downloads">downloads</label></div>
+                <div><input class="gistbox-sort-option" id="gistbox-sort-option-rating" type="radio" name="sort-option" value="rating"> <label class="gistbox-sort-label" for="gistbox-sort-option-rating">rating</label></div>
             </span>
         </div>
     </div>
@@ -71,17 +72,36 @@ function sortByUpdated() {
         return B.updated.localeCompare(A.updated);
     })
     items.forEach(function(i) { i.li.appendTo(list)});
-
+}
+function sortByRating() {
+    var list = $("ul.gistlist");
+    list.children().detach();
+    items.sort(function(A,B) {
+        if (B.score!=A.score){
+            return (B.score-A.score);
+        } else {
+            return (B.count-A.count);
+        }
+    })
+    items.forEach(function(i) { i.li.appendTo(list)});
 }
 
 $(function() {
 
-
     $(".gistbox").each(function(e) {
         var d = ($(this).find("h1").text()+" "+$(this).data("tags")+" "+$(this).data("owner")).toLowerCase();
         $(this).data("info", d);
+        var scoreElem = $(this).find(".gistbox-score");
+        scoreElem.text(Number($(this).data("score")).toFixed(1));
         gistCount++;
-        items.push({li:$(this), info:$(this).data("info"), downloads:$(this).data('downloads'), updated:$(this).data('updated')});
+        items.push({
+            li:$(this),
+            info:$(this).data("info"),
+            downloads:$(this).data('downloads'),
+            updated:$(this).data('updated'),
+            score:$(this).data('score'),
+            count:$(this).data('count')
+        });
     });
 
     updateCount(gistCount);
@@ -109,13 +129,17 @@ $(function() {
     },200);
 
     $(".gistbox-sort-option").change(function() {
-        if ($(this).val() === "downloads") {
-            sortByDownload();
-        } else {
-            sortByUpdated();
+        switch ($(this).val()) {
+            case "downloads":
+                sortByDownload();
+                break;
+            case "updated":
+                sortByUpdated();
+                break;
+            case "rating":
+                sortByRating();
+                break;
         }
     });
-
-
 });
 </script>

--- a/template/_nodebox.html
+++ b/template/_nodebox.html
@@ -1,11 +1,19 @@
-<li class="gistbox gistbox-{{type}}" data-tags="{{keywords}}" data-owner="{{author.name}}" data-updated="{{updated_at}}" data-downloads="{{downloads.week}}"><a href="/node/{{name}}">
+<li class="gistbox gistbox-{{type}}" 
+    data-tags="{{keywords}}"
+    data-owner="{{author.name}}"
+    data-updated="{{updated_at}}"
+    data-downloads="{{downloads.week}}"
+    data-score="{{rating.score}}"
+    data-count="{{rating.count}}"><a href="/node/{{name}}">
 <h1 class="gisttitle">{{name}}</h1>
 <p class="gistdescription">{{description}}</p>
 <div class="gistbox-footer">
     <div class="gistbox-type">
         <!-- {{#official}}<img alt="maintained by the Node-RED project" title="maintained by the Node-RED project" src="/node-red-white.png" class="gistbox-official" />{{/official}} -->
-        {{#dist-tags.latest}} v{{.}} &nbsp;&nbsp;{{/dist-tags.latest}}
-        {{#downloads}} <i class="fa fa-cloud-download"></i> {{week}} &nbsp;&nbsp;{{/downloads}}
+        {{#dist-tags.latest}} v{{.}} &nbsp;{{/dist-tags.latest}}
+        {{#downloads}} <i class="fa fa-cloud-download"></i> {{week}} &nbsp;{{/downloads}}
+        {{#rating}}<i class="fa fa-star"></i><span class="gistbox-score">{{score}}</span> ({{count}} <i class="fa fa-user"></i>){{/rating}}
+       
         <!-- {{#updated_formatted}} <i class="fa fa-clock-o"></i> {{updated_formatted}} {{/updated_formatted}} -->
     </div>
     <div class="gistbox-owner">{{type}}</div>

--- a/test/lib/modules_spec.js
+++ b/test/lib/modules_spec.js
@@ -10,52 +10,52 @@ var modules = require('../../lib/modules');
 
 describe("modules", function () {
 
-  afterEach(function () {
-    sandbox.restore();
-  });
-
-  it('#pruneRatings', function (done) {
-    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
-    sandbox.stub(ratings, 'getRatedModules').returns(when(list));
-    sandbox.stub(nodes, 'get').returns(when({
-      _id: 'node-red-dashboard'
-    })).returns(when({
-      _id: 'node-red-contrib-influxdb'
-    })).returns(when({
-      _id: 'node-red-contrib-noble'
-    }));
-
-    modules.pruneRatings().then(function (results) {
-      results.should.be.empty();
-      done();
+    afterEach(function () {
+        sandbox.restore();
     });
-  });
 
-  it('#pruneRatings module removed', function (done) {
-    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
-    sandbox.stub(ratings, 'getRatedModules').returns(when(list));
+    it('#pruneRatings', function (done) {
+        var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+        sandbox.stub(ratings, 'getRatedModules').returns(when(list));
+        sandbox.stub(nodes, 'get').returns(when({
+            _id: 'node-red-dashboard'
+        })).returns(when({
+            _id: 'node-red-contrib-influxdb'
+        })).returns(when({
+            _id: 'node-red-contrib-noble'
+        }));
 
-    var nodesGet = sandbox.stub(nodes, 'get')
-    nodesGet.withArgs('node-red-dashboard').returns(when({
-      _id: 'node-red-dashboard'
-    }));
-    nodesGet.withArgs('node-red-contrib-influxdb').returns(when({
-      _id: 'node-red-contrib-influxdb'
-    }));
-    nodesGet.withArgs('node-red-contrib-noble').returns(
-      when.reject(new Error('node not found: node-red-contrib-noble')));
-
-    var removeForModule = sandbox.stub(ratings, 'removeForModule').returns(when());
-    sandbox.stub(events, 'add').returns(when());
-
-    modules.pruneRatings().then(function (results) {
-      results.should.have.length(1);
-      results[0].should.eql({
-        state: 'fulfilled',
-        value: 'node-red-contrib-noble ratings removed'
-      });
-      done();
+        modules.pruneRatings().then(function (results) {
+            results.should.be.empty();
+            done();
+        });
     });
-  });
+
+    it('#pruneRatings module removed', function (done) {
+        var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+        sandbox.stub(ratings, 'getRatedModules').returns(when(list));
+
+        var nodesGet = sandbox.stub(nodes, 'get')
+        nodesGet.withArgs('node-red-dashboard').returns(when({
+            _id: 'node-red-dashboard'
+        }));
+        nodesGet.withArgs('node-red-contrib-influxdb').returns(when({
+            _id: 'node-red-contrib-influxdb'
+        }));
+        nodesGet.withArgs('node-red-contrib-noble').returns(
+            when.reject(new Error('node not found: node-red-contrib-noble')));
+
+        var removeForModule = sandbox.stub(ratings, 'removeForModule').returns(when());
+        sandbox.stub(events, 'add').returns(when());
+
+        modules.pruneRatings().then(function (results) {
+            results.should.have.length(1);
+            results[0].should.eql({
+                state: 'fulfilled',
+                value: 'node-red-contrib-noble ratings removed'
+            });
+            done();
+        });
+    });
 
 });

--- a/test/lib/modules_spec.js
+++ b/test/lib/modules_spec.js
@@ -1,0 +1,61 @@
+var should = require('should');
+var sinon = require('sinon');
+var when = require('when');
+var nodes = require('../../lib/nodes');
+var ratings = require('../../lib/ratings');
+var events = require('../../lib/events');
+var sandbox = sinon.createSandbox();
+
+var modules = require('../../lib/modules');
+
+describe("modules", function () {
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('#pruneRatings', function (done) {
+    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+    sandbox.stub(ratings, 'getRatedModules').returns(when(list));
+    sandbox.stub(nodes, 'get').returns(when({
+      _id: 'node-red-dashboard'
+    })).returns(when({
+      _id: 'node-red-contrib-influxdb'
+    })).returns(when({
+      _id: 'node-red-contrib-noble'
+    }));
+
+    modules.pruneRatings().then(function (results) {
+      results.should.be.empty();
+      done();
+    });
+  });
+
+  it('#pruneRatings module removed', function (done) {
+    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+    sandbox.stub(ratings, 'getRatedModules').returns(when(list));
+
+    var nodesGet = sandbox.stub(nodes, 'get')
+    nodesGet.withArgs('node-red-dashboard').returns(when({
+      _id: 'node-red-dashboard'
+    }));
+    nodesGet.withArgs('node-red-contrib-influxdb').returns(when({
+      _id: 'node-red-contrib-influxdb'
+    }));
+    nodesGet.withArgs('node-red-contrib-noble').returns(
+      when.reject(new Error('node not found: node-red-contrib-noble')));
+
+    var removeForModule = sandbox.stub(ratings, 'removeForModule').returns(when());
+    sandbox.stub(events, 'add').returns(when());
+
+    modules.pruneRatings().then(function (results) {
+      results.should.have.length(1);
+      results[0].should.eql({
+        state: 'fulfilled',
+        value: 'node-red-contrib-noble ratings removed'
+      });
+      done();
+    });
+  });
+
+});

--- a/test/lib/ratings_spec.js
+++ b/test/lib/ratings_spec.js
@@ -1,0 +1,129 @@
+var should = require('should');
+var sinon = require('sinon');
+
+var db = require('../../lib/db');
+var ratings = require('../../lib/ratings');
+var sandbox = sinon.createSandbox();
+
+describe("ratings", function() {
+
+  afterEach(function () {
+      sandbox.restore();
+  });
+
+  it('#save', function(done) {
+    var dbUpdate = sandbox.stub(db.ratings, 'update').yields(null);
+
+    var testRating = {
+      user: 'testuser',
+      module: 'node-red-dashboard',
+      time: new Date(),
+      rating: 4
+    };
+
+    ratings.save(testRating).then(function() {
+      sinon.assert.calledWith(dbUpdate,
+        {module: testRating.module, user: testRating.user}, testRating, {upsert: true});
+      done();
+    }).otherwise(function(err) {
+      done(err);
+    });
+  });
+
+  it('#remove', function(done) {
+    var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
+    var testRating = {
+      user: 'testuser',
+      module: 'node-red-dashboard'
+    };
+    ratings.remove(testRating).then(function() {
+      sinon.assert.calledWith(dbRemove, testRating);
+      done();
+    }).otherwise(function(err) {
+      done(err);
+    });
+  });
+
+  it('#get', function(done) {
+    var totalRating = [{ _id: 'node-red-dashboard', total: 19, count: 2 }];
+    var userRating = {
+      user: 'test',
+      module: 'node-red-dashboard',
+      rating: 4,
+      version: '2.6.1',
+      time: new Date('2018-01-15T00:34:27.998Z')
+    };
+
+    sandbox.stub(db.ratings, 'aggregate').yields(null,
+      totalRating
+    );
+
+    sandbox.stub(db.ratings, 'findOne').yields(null, userRating);
+
+    ratings.get('node-red-dashboard', 'test').then(function(found) {
+      found.should.eql({
+        module:'node-red-dashboard',
+        total: 19,
+        count: 2,
+        userRating: {
+          user: 'test',
+          module: 'node-red-dashboard',
+          rating: 4,
+          version: '2.6.1',
+          time: new Date('2018-01-15T00:34:27.998Z')
+        }
+      });
+      done();
+    }).otherwise(function(err) {
+      done(err);
+    });
+  });
+
+  it('#get no user rating', function(done) {
+    sandbox.stub(db.ratings, 'aggregate').yields(null,
+      [{ _id: 'node-red-dashboard', total: 19, count: 2}]
+    );
+    var foundRating = {
+      user: 'test',
+      module: 'node-red-dashboard',
+      rating: 4,
+      version: '2.6.1',
+      time: new Date('2018-01-15T00:34:27.998Z')
+    };
+
+    var dbFindOne = sandbox.stub(db.ratings, 'findOne').yields(null, 
+      foundRating
+    );
+
+    ratings.get('node-red-dashboard').then(function(found) {
+      found.should.eql({
+        module: 'node-red-dashboard',
+        total: 19, count: 2
+      });
+      sinon.assert.notCalled(dbFindOne);
+      done();
+    }).otherwise(function(err) {
+      done(err);
+    });
+  });
+
+  it('#getRatedModules', function(done) {
+    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+    sandbox.stub(db.ratings, 'distinct').yields(null, list);
+
+    ratings.getRatedModules().then(function(modList) {
+      modList.should.eql(list);
+      done();
+    });
+  });
+
+  it('#removeForModule', function(done) {
+    var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
+
+    ratings.removeForModule('node-red-dashboard').then(function() {
+      sinon.assert.calledWith(dbRemove, {module: 'node-red-dashboard'});
+      done();
+    });
+  });
+});
+

--- a/test/lib/ratings_spec.js
+++ b/test/lib/ratings_spec.js
@@ -5,125 +5,125 @@ var db = require('../../lib/db');
 var ratings = require('../../lib/ratings');
 var sandbox = sinon.createSandbox();
 
-describe("ratings", function() {
+describe("ratings", function () {
 
-  afterEach(function () {
-      sandbox.restore();
-  });
-
-  it('#save', function(done) {
-    var dbUpdate = sandbox.stub(db.ratings, 'update').yields(null);
-
-    var testRating = {
-      user: 'testuser',
-      module: 'node-red-dashboard',
-      time: new Date(),
-      rating: 4
-    };
-
-    ratings.save(testRating).then(function() {
-      sinon.assert.calledWith(dbUpdate,
-        {module: testRating.module, user: testRating.user}, testRating, {upsert: true});
-      done();
-    }).otherwise(function(err) {
-      done(err);
+    afterEach(function () {
+        sandbox.restore();
     });
-  });
 
-  it('#remove', function(done) {
-    var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
-    var testRating = {
-      user: 'testuser',
-      module: 'node-red-dashboard'
-    };
-    ratings.remove(testRating).then(function() {
-      sinon.assert.calledWith(dbRemove, testRating);
-      done();
-    }).otherwise(function(err) {
-      done(err);
+    it('#save', function (done) {
+        var dbUpdate = sandbox.stub(db.ratings, 'update').yields(null);
+
+        var testRating = {
+            user: 'testuser',
+            module: 'node-red-dashboard',
+            time: new Date(),
+            rating: 4
+        };
+
+        ratings.save(testRating).then(function () {
+            sinon.assert.calledWith(dbUpdate,
+                { module: testRating.module, user: testRating.user }, testRating, { upsert: true });
+            done();
+        }).otherwise(function (err) {
+            done(err);
+        });
     });
-  });
 
-  it('#get', function(done) {
-    var totalRating = [{ _id: 'node-red-dashboard', total: 19, count: 2 }];
-    var userRating = {
-      user: 'test',
-      module: 'node-red-dashboard',
-      rating: 4,
-      version: '2.6.1',
-      time: new Date('2018-01-15T00:34:27.998Z')
-    };
-
-    sandbox.stub(db.ratings, 'aggregate').yields(null,
-      totalRating
-    );
-
-    sandbox.stub(db.ratings, 'findOne').yields(null, userRating);
-
-    ratings.get('node-red-dashboard', 'test').then(function(found) {
-      found.should.eql({
-        module:'node-red-dashboard',
-        total: 19,
-        count: 2,
-        userRating: {
-          user: 'test',
-          module: 'node-red-dashboard',
-          rating: 4,
-          version: '2.6.1',
-          time: new Date('2018-01-15T00:34:27.998Z')
-        }
-      });
-      done();
-    }).otherwise(function(err) {
-      done(err);
+    it('#remove', function (done) {
+        var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
+        var testRating = {
+            user: 'testuser',
+            module: 'node-red-dashboard'
+        };
+        ratings.remove(testRating).then(function () {
+            sinon.assert.calledWith(dbRemove, testRating);
+            done();
+        }).otherwise(function (err) {
+            done(err);
+        });
     });
-  });
 
-  it('#get no user rating', function(done) {
-    sandbox.stub(db.ratings, 'aggregate').yields(null,
-      [{ _id: 'node-red-dashboard', total: 19, count: 2}]
-    );
-    var foundRating = {
-      user: 'test',
-      module: 'node-red-dashboard',
-      rating: 4,
-      version: '2.6.1',
-      time: new Date('2018-01-15T00:34:27.998Z')
-    };
+    it('#get', function (done) {
+        var totalRating = [{ _id: 'node-red-dashboard', total: 19, count: 2 }];
+        var userRating = {
+            user: 'test',
+            module: 'node-red-dashboard',
+            rating: 4,
+            version: '2.6.1',
+            time: new Date('2018-01-15T00:34:27.998Z')
+        };
 
-    var dbFindOne = sandbox.stub(db.ratings, 'findOne').yields(null, 
-      foundRating
-    );
+        sandbox.stub(db.ratings, 'aggregate').yields(null,
+            totalRating
+        );
 
-    ratings.get('node-red-dashboard').then(function(found) {
-      found.should.eql({
-        module: 'node-red-dashboard',
-        total: 19, count: 2
-      });
-      sinon.assert.notCalled(dbFindOne);
-      done();
-    }).otherwise(function(err) {
-      done(err);
+        sandbox.stub(db.ratings, 'findOne').yields(null, userRating);
+
+        ratings.get('node-red-dashboard', 'test').then(function (found) {
+            found.should.eql({
+                module: 'node-red-dashboard',
+                total: 19,
+                count: 2,
+                userRating: {
+                    user: 'test',
+                    module: 'node-red-dashboard',
+                    rating: 4,
+                    version: '2.6.1',
+                    time: new Date('2018-01-15T00:34:27.998Z')
+                }
+            });
+            done();
+        }).otherwise(function (err) {
+            done(err);
+        });
     });
-  });
 
-  it('#getRatedModules', function(done) {
-    var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
-    sandbox.stub(db.ratings, 'distinct').yields(null, list);
+    it('#get no user rating', function (done) {
+        sandbox.stub(db.ratings, 'aggregate').yields(null,
+            [{ _id: 'node-red-dashboard', total: 19, count: 2 }]
+        );
+        var foundRating = {
+            user: 'test',
+            module: 'node-red-dashboard',
+            rating: 4,
+            version: '2.6.1',
+            time: new Date('2018-01-15T00:34:27.998Z')
+        };
 
-    ratings.getRatedModules().then(function(modList) {
-      modList.should.eql(list);
-      done();
+        var dbFindOne = sandbox.stub(db.ratings, 'findOne').yields(null,
+            foundRating
+        );
+
+        ratings.get('node-red-dashboard').then(function (found) {
+            found.should.eql({
+                module: 'node-red-dashboard',
+                total: 19, count: 2
+            });
+            sinon.assert.notCalled(dbFindOne);
+            done();
+        }).otherwise(function (err) {
+            done(err);
+        });
     });
-  });
 
-  it('#removeForModule', function(done) {
-    var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
+    it('#getRatedModules', function (done) {
+        var list = ['node-red-dashboard', 'node-red-contrib-influxdb', 'node-red-contrib-noble'];
+        sandbox.stub(db.ratings, 'distinct').yields(null, list);
 
-    ratings.removeForModule('node-red-dashboard').then(function() {
-      sinon.assert.calledWith(dbRemove, {module: 'node-red-dashboard'});
-      done();
+        ratings.getRatedModules().then(function (modList) {
+            modList.should.eql(list);
+            done();
+        });
     });
-  });
+
+    it('#removeForModule', function (done) {
+        var dbRemove = sandbox.stub(db.ratings, 'remove').yields(null);
+
+        ratings.removeForModule('node-red-dashboard').then(function () {
+            sinon.assert.calledWith(dbRemove, { module: 'node-red-dashboard' });
+            done();
+        });
+    });
 });
 


### PR DESCRIPTION
added task to delete user ratings for nodes that have been removed
fixed events.add() promise not resolving when slack not configured
added some simple unit tests for prune ratings task, and ratings module
made changes to templates to display rating, count, sort by rating count
copy ratings from db to new doc when updating node
tested by walking through code in debugger locally with a few nodes and flows