### PR TITLE
Add link from modules list to flows library

### DIFF
--- a/template/flowInspector.html
+++ b/template/flowInspector.html
@@ -126,7 +126,7 @@ $(function() {
                 var modules = Object.keys(moduleList);
                 modules.sort();
                 modules.forEach(function(m) {
-                    report += ' - '+m+'\n';
+                    report += ' - <a href="https://flows.nodered.org/node/' + m + '" target="_blank">' + m + '</a>\n';
                 })
 
 


### PR DESCRIPTION
Apologies but I can't actually test this change at the moment as I don't have a docker environment available.

In particular, it would be good to find a flow that contains a scoped node.

The link is only added to the modules summary at the end and is set to open the appropriate entry in the flows library in a new tab.