### PR TITLE
Handle non-string event messages

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -58,8 +58,8 @@ function addEvent(event) {
                     };
 
 
-                    if (event.message && event.action !== 'started') {
-                        json.attachments[0].text = event.message.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+                    if (event.hasOwnProperty("message") && event.action !== 'started') {
+                        json.attachments[0].text = (""+event.message).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
                     }
                     var options = {
                         url: settings.slack.webhook,
@@ -77,6 +77,7 @@ function addEvent(event) {
                     resolve();
                 }
             } else {
+                console.log("Event:",JSON.stringify(event));
                 resolve();
             }
         });


### PR DESCRIPTION
More specifically, rating events have a numeric message payload.