### PR TITLE
Change wording on scorecard

### DIFF
--- a/template/scorecard.html
+++ b/template/scorecard.html
@@ -151,7 +151,7 @@
                 <div style="width: 100px">
                     {{#scorecard.D02}}{{>_scorecardResult}}{{/scorecard.D02}}
                 </div>
-                <div style="flex-grow:1;font-size:1.3em">No known incompatible packages
+                <div style="flex-grow:1;font-size:1.3em">Check for Incompatible packages
                     {{^scorecard.D02.test}}
                     <div style="color: #aaa;font-size: 0.8em">
                         {{#scorecard.D02.packages}} {{.}}, {{/scorecard.D02.packages}}


### PR DESCRIPTION
Change the label as it looks odd when there is a fail and a ❌ saying No Known Incompatible Packages eg https://flows.nodered.org/node/node-red-contrib-mos-ru/scorecard