### PR TITLE
fix for saving scoped package scorecards (#74)

### DIFF
--- a/lib/scorecard.js
+++ b/lib/scorecard.js
@@ -7,10 +7,10 @@ const events = require('./events')
 
 function scorecard(packagename, version, nodePath) {
     var fileid = crypto.randomBytes(4).toString("hex");
-    nodereddev.run(["validate",  "-p", nodePath, "-o", `${nodePath}/../${packagename}-${fileid}.json`, "-e", "true"])
+    nodereddev.run(["validate",  "-p", nodePath, "-o", `${nodePath}/../${fileid}.json`, "-e", "true"])
     .then(require('@oclif/command/flush'))
     .then(() => {
-        var card = fs.readJsonSync(`${nodePath}/../${packagename}-${fileid}.json`)
+        var card = fs.readJsonSync(`${nodePath}/../${fileid}.json`)
         return npmNodes.update(packagename, {"scorecard" : card}).then(() => card)
     }).then((card) => {
         fs.removeSync(nodePath+'/../..');


### PR DESCRIPTION
* fix for saving scoped package scorecards

* temp disable csrf on addNode

* testing timeout

* update timeout

* add error

* throw

* revert

* Revert "revert"

This reverts commit f4549b85140ac403827bf4705d3f1941adfbd53c.

* Revert "throw"

This reverts commit 20bc64444d05098f2be552edf39fd5a161dfee14.

* Revert "add error"

This reverts commit 6455732d36c7adafe54d5a1f551c370754e42a97.

* Revert "update timeout"

This reverts commit 61df237a9972a68194e08ea6c1980618ff2a9384.

* Revert "testing timeout"

This reverts commit a879e352175796c0bfe3172319043833175ea57d.

* Revert "temp disable csrf on addNode"

This reverts commit 3b4990092684845b1446ddeec84d4c07ac74427d.