### PR TITLE
Show node version even on test fail

### DIFF
--- a/template/scorecard.html
+++ b/template/scorecard.html
@@ -80,8 +80,7 @@
                 </div>
                 <div style="flex-grow:1;font-size:1.3em">Node.js Version:
                     <span style="color: #aaa">
-                    {{#scorecard.P07.test}}{{scorecard.P07.version}}{{/scorecard.P07.test}}
-                    {{^scorecard.P07.test}}Missing{{/scorecard.P07.test}}
+                        {{scorecard.P07.version}}{{^scorecard.P07.version}}Missing{{/scorecard.P07.version}}                      
                     </span>
                 </div>
                 <div style="font-size: 1.3em"><a href="#" onclick="showRule('P07');"><i class="ruleinfo fa fa-info-circle"></i></a></div>


### PR DESCRIPTION
This PR addresses https://github.com/node-red/node-red-dev-cli/issues/14 such that if test P07 fails because the version is specified but does not meet the current minimum node-red version it will show the version number but still add a warning instead of showing `missing`