### PR TITLE
Add some debug to track down scorecard mismatch

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -161,10 +161,10 @@ async function getLatestVersion(name, knownVersion) {
                 fs.removeSync(packagePath);
                 fs.ensureDirSync(packagePath);
 
-                util.log(name,'getting tarball')
+                util.log(name,'getting tarball', tarfile)
 
                 request(tarballUrl).pipe(fs.createWriteStream(tarfile)).on('finish', function() {
-                    util.log(name,'finished getting tarball, extracting...')
+                    util.log(name,'finished getting tarball, extracting to', packagePath)
                     extractTarball(tarfile,packagePath).then(function() {
                         util.log(name,'finished extracting')
                         //console.log("Extracted:",name);

--- a/lib/scorecard.js
+++ b/lib/scorecard.js
@@ -1,3 +1,4 @@
+const util = require("util");
 var nodereddev = require('node-red-dev')
 var crypto = require("crypto");
 const npmNodes = require('./nodes');
@@ -7,13 +8,20 @@ const events = require('./events')
 
 function scorecard(packagename, version, nodePath) {
     var fileid = crypto.randomBytes(4).toString("hex");
+    util.log('Running scorecard', packagename, version, nodePath)
+    try {
+        const pkg = fs.readJsonSync(nodePath+'/package.json')
+        util.log(' - Scorecard package.json:', pkg.name, pkg.version)
+    } catch(err) {
+        util.log(' - Error checking packaging:', err)
+    }
     nodereddev.run(["validate",  "-p", nodePath, "-o", `${nodePath}/../${fileid}.json`, "-e", "true"])
     .then(require('@oclif/command/flush'))
     .then(() => {
         var card = fs.readJsonSync(`${nodePath}/../${fileid}.json`)
         return npmNodes.update(packagename, {"scorecard" : card}).then(() => card)
     }).then((card) => {
-        fs.removeSync(nodePath+'/../..');
+        // fs.removeSync(nodePath+'/../..');
         let message = 'Result: ';
 
         const keys = Object.keys(card);
@@ -57,7 +65,7 @@ function scorecard(packagename, version, nodePath) {
             version: version,
             message: error.message
         });
-        fs.removeSync(nodePath+'/../..');
+        // fs.removeSync(nodePath+'/../..');
     })
 }
 


### PR DESCRIPTION
We still see the scorecards being generated against the wrong package version.

This PR adds some debug to try to track it down as I haven't been able to reproduce it locally.