### PR TITLE
Slight rework on embed options

### DIFF
--- a/public/css/library.css
+++ b/public/css/library.css
@@ -234,7 +234,7 @@ h1 {
     color: #f3f3f3;
 }
 
-#flow {
+.flow {
     margin-top: 30px;
     margin-bottom: 30px;
     padding: 10px;
@@ -1367,7 +1367,7 @@ body.flowviewer-share {
 .dialog  > div:not(:last-child) {
     margin-bottom: 20px;
 }
-.dialog button {
+.dialog button:not(.copy-button) {
     line-height: 1.3em;
     border: 1px solid #aa6767;
     text-align: center;

--- a/routes/flows.js
+++ b/routes/flows.js
@@ -81,6 +81,7 @@ function getShareableFlow (id, collection, req, res) {
     gister.get(id)
         .then(function(gist) {
             gist.flow = parseGistFlow(gist)
+            gist.isShare = true
             res.send(mustache.render(templates.gistShare, gist, templates.partials));
         }).catch(function(err) {
             // TODO: better error logging without the full stack trace

--- a/template/_flowViewer.html
+++ b/template/_flowViewer.html
@@ -97,20 +97,40 @@
     color: rgb(196, 59, 59); 
     width: 100%;
 }
+.flowviewer-share-details {
+    padding: 5px;
+    border: 1px solid #aa6767;
+    background: white;
+    border-bottom-right-radius: 3px;
+    border-top-left-radius: 3px;
+    font-size: 0.8em;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}
 </style>
 
 <div>
     <div class="flowviewer">
-        <svg>
-            <g class="flowGridlines"></g>
-            <g class="containerGroup"></g>
-            <g class="flowGroups"></g>
-            <g class="flowWires"></g>
-            <g class="flowNodes"></g>
-        </svg>
-        <button id="copy-flow" class="copy-button">Copy JSON</button>
+        <div style="position: relative">
+            <svg>
+                <g class="flowGridlines"></g>
+                <g class="containerGroup"></g>
+                <g class="flowGroups"></g>
+                <g class="flowWires"></g>
+                <g class="flowNodes"></g>
+            </svg>
+            <button id="copy-flow" class="copy-button">Copy JSON</button>
+{{#isShare}}
+            <label class="flowviewer-share-details">
+                <a href="/flow/{{ id }}" target="_blank">{{description}}</a> by <a href="/user/{{ owner.login }}">{{ owner.login }}</a>
+            </label>
+{{/isShare}}
+        </div>
         <div class="flowviewer-tabs"></div>
+{{^isShare}}
         <label class="flowviewer-note">Note: some third-party nodes may appear with blank styling, and not as they appear in the Node-RED Editor.</label>
+{{/isShare}}
     </div>
 </div>
 
@@ -144,7 +164,7 @@
                         tabs.push({
                             id: d.z,
                             label: d.z,
-                            type: 'tab'
+                            type: 'tab',
                         })
                     }
                 }
@@ -199,7 +219,7 @@
 
         function addTab (tab, index) {
             const classes = 'flowviewer-tab flowviewer-' + tab.type
-            const name = tab.type === 'tab' ? 'Tab ' + (index + 1) : tab.label
+            const name = tab.type === 'tab' ? 'Flow ' + (index + 1) : tab.label
             const tabDOM = $('.flowviewer-tabs')
                 .append(`<div id="flowviewer-tab-${index}" class="${classes}">${name}</div>`)
                 .on('click', `#flowviewer-tab-${index}`, function () {

--- a/template/flowInspector.html
+++ b/template/flowInspector.html
@@ -7,7 +7,7 @@
             <p>Paste your flow and click inspect. This will generate a report about the contents of the flow. It will attempt
             to identify what node modules are used by the flow based on the node types. If there is more than one possible
             module for a given node type, all of the candidate modules will be listed.</p>
-            <textarea id="flow"></textarea>
+            <textarea id="flow" class="flow"></textarea>
             <div style="position:relative; top: -35px;"><div class="flow-warning dialog-warning">The flow must contain at least one node</div></div>
 
             <a id="inspect" href="#" class="btn-create">inspect flow</a>

--- a/template/gist.html
+++ b/template/gist.html
@@ -5,12 +5,7 @@
         <h1 class="flow-title">{{ description }}</h1>
         {{{ readme }}}
         {{>_flowViewer}}
-        <h2><code>flow.json</code></h2>
-        <pre id="flow" class="highlight language-javascript"><button class="copy-button" type="button">Copy</button><span>{{ flow }}</span></pre>
-        <h2>Embed Flow Viewer</h2>
-        <p>If you would like to share this flow inside an article, or on your own website, you can include the following code in your site. This will render the above Flow Viewer.</p>
-        <pre id="flow" class="highlight language-html"><button class="copy-button" type="button">Copy</button><span id="flowviewer-embedcode"></span>
-        </pre>
+        <pre id="flow" class="flow highlight language-javascript"><button class="copy-button copy-flow-button" type="button">Copy</button><span>{{ flow }}</span></pre>
     </div>
     <div class="col-3-12">
         {{>_collectionNavBox}}
@@ -33,11 +28,12 @@
                 <input name="rating" type="hidden">
                 <div class="flowinfo">Rate: <span id="set-stars"></span></div>
             </form>
+            <div class="flowinfo" style="text-align: left;"><a class="user-profile-action" href="#" id="embed-flow">share flow</a></div>            
             {{#sessionuser}}
-            <div class="flowinfo" style="text-align: right;"><a class="user-profile-action" href="#" onclick="javascript:addToCollection('{{_id}}');">add to collection</a></div>
+            <div class="flowinfo" style="text-align: left;"><a class="user-profile-action" href="#" onclick="javascript:addToCollection('{{_id}}');">add to collection</a></div>
             {{#owned}}
-                <div class="flowinfo" style="text-align: right;"><img id="refresh-flow-loader" class="loader" src="/images/loader.gif" />&nbsp;&nbsp;<a class="user-profile-action" id="refresh-flow" href="#">refresh from github</a></div>
-                <div class="flowinfo" style="text-align: right;"><a class="user-profile-action" id="remove-flow" href="#">remove flow</a></div>
+                <div class="flowinfo" style="text-align: left;"><a class="user-profile-action" id="refresh-flow" href="#">refresh from github</a>&nbsp;&nbsp;<img id="refresh-flow-loader" class="loader" src="/images/loader.gif" /></div>
+                <div class="flowinfo" style="text-align: left;"><a class="user-profile-action" id="remove-flow" href="#">remove flow</a></div>
             {{/owned}}
           {{/sessionuser}}
         </div>
@@ -86,24 +82,38 @@
 <script src="/js/tags.js"></script>
 <script>
 $(function() {
-    $(".copy-button").on("click", function(evt) {
+    function attachCopy(selector) {
+        $(selector).on("click", function(evt) {
+            evt.preventDefault();
+            var ta = document.createElement('textarea');
+            ta.value = $(this).next()[0].innerText;
+            ta.style.position = 'absolute';
+            ta.style.left = '-3000px';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            $(this).text("Copied!");
+            var self = $(this);
+            setTimeout(function() {
+                self.text("Copy");
+            },3000)
+        });
+    }
+    attachCopy(".copy-flow-button")
+    
+    $('#embed-flow').click(function(evt) {
         evt.preventDefault();
-        var ta = document.createElement('textarea');
-        ta.value = $(this).next()[0].innerText;
-        ta.style.position = 'absolute';
-        ta.style.left = '-3000px';
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-        $(this).text("Copied!");
-        var self = $(this);
-        setTimeout(function() {
-            self.text("Copy");
-        },3000)
+        var dialog = $('<div class="dialog-shade"><div class="dialog">'+
+            '<h4>Share this flow</h4>'+
+            '<p>Use the following code to embed the flow viewer on your own site.</p>'+
+            '<pre class="flow highlight language-html"><button class="copy-button copy-embed-button" type="button">Copy</button><span id="flowviewer-embedcode">'+
+            '&lt;iframe width="100%" height="100%" src="' + window.location + '/share" allow="clipboard-read; clipboard-write" style="border: none;"&gt&lt;/iframe&gt;'+
+            '</span></pre>'+
+            '<div class="dialog-buttons"><button type="button" onclick="return closeDialog();">Done</button></div>'+
+            '</div></div>').appendTo('body').show();
+        attachCopy(".copy-embed-button")
     });
-    $('#flowviewer-embedcode').html('&lt;iframe width="100%" height="100%" src="' + window.location + '/share" allow="clipboard-read; clipboard-write" style="border: none;"&gt&lt;/iframe&gt;');
-
 {{#owned}}
     $('#refresh-flow').click(function(event) {
         $("#refresh-flow-loader").show();

--- a/template/gistShare.html
+++ b/template/gistShare.html
@@ -34,7 +34,5 @@
 </head>
 <body class="flowviewer-share">
 {{>_flowViewer}}
-
-<script>
-    $('.flowviewer-note').hide()
-</script>
+</body>
+</html>


### PR DESCRIPTION
This is a slight rework on the share/embed options added in #100 

I have moved the share option over to the actions sidebar:

<img width="252" alt="image" src="https://github.com/node-red/flow-library/assets/51083/c2d89486-7160-4cd2-b28c-4e8f1bf11086">

Clicking the option opens a dialog with:

<img width="603" alt="image" src="https://github.com/node-red/flow-library/assets/51083/6976c1a3-77ed-4457-abea-48c8c332e4d4">


When viewing the embedded flow, I've added a title/author link in the bottom corner as I think it's important to link back and include attribution.

And changed the default label to 'Flow' rather than 'Tab' to be consistent with the editor.


<img width="747" alt="image" src="https://github.com/node-red/flow-library/assets/51083/f3661c7d-7e5e-44f3-a661-10d90b57324e">
