### PR TITLE
Allow definition of "?height" in the share URL

### DIFF
--- a/routes/flows.js
+++ b/routes/flows.js
@@ -82,6 +82,7 @@ function getShareableFlow (id, collection, req, res) {
         .then(function(gist) {
             gist.flow = parseGistFlow(gist)
             gist.isShare = true
+            gist.minHeight = req.query.height || 450
             res.send(mustache.render(templates.gistShare, gist, templates.partials));
         }).catch(function(err) {
             // TODO: better error logging without the full stack trace

--- a/template/gistShare.html
+++ b/template/gistShare.html
@@ -31,6 +31,11 @@
 	<link href="/css/library.css?d=20201113" rel="stylesheet" media="screen">
 	<link href="/font-awesome/css/font-awesome.min.css" rel="stylesheet" media="screen">
 	<script src="/jquery/js/jquery-1.9.1.js"></script>
+    <style>
+        .flowviewer svg {
+            min-height: {{minHeight}}px;
+        }
+    </style>
 </head>
 <body class="flowviewer-share">
 {{>_flowViewer}}


### PR DESCRIPTION
Went to embed this into an article, with a very simple flow all in a horizontal line, but it meant that there was a lot of waste space.

A quick win was to be able to define a height (which in turn sets `min-height` on the SVG within the iframe) such that we have more control over how it's rendered.

Default `min-height` is still `450px` if nothing is provided.