### PR TITLE
Support marking module as deprecated

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -97,6 +97,8 @@ async function getLatestVersion (name, knownVersion) {
             const tarballUrl = info.versions[latest].dist.tarball
             const tarfile = path.join(nodePath, path.basename(tarballUrl))
 
+            info.deprecated = info.versions[latest].deprecated || false
+
             const packagePath = path.join(nodePath, 'package')
             async function completeUpdate () {
                 console.log(name, 'completeUpgrade done')

--- a/public/css/library.css
+++ b/public/css/library.css
@@ -1362,7 +1362,8 @@ body.flowviewer-share {
     border-bottom-left-radius: 15px;
 
 }
-#report-node-dialog textarea {
+#report-node-dialog textarea,
+#edit-node-deprecation textarea {
     border: 1px solid #999;
     font-size: 14px;
     width: 100%;
@@ -1712,4 +1713,24 @@ span.username {
     right: 10px;
     top: 12px;
 
+}
+
+.deprecated-notice {
+    display: block;
+    border: 2px solid #eec0c0;
+    background: #eec0c0;
+    padding: 8px;
+    border-bottom-left-radius: 8px;
+    border-top-right-radius: 8px;
+    margin-bottom: 30px;
+}
+.deprecated-notice h1 {
+    margin: 10px 0;
+    font-size: 22px;
+}
+.deprecated-notice code {
+    display: block;
+    padding: 8px;
+    border-top-right-radius: 8px;
+    border-bottom-left-radius: 8px;
 }

--- a/tasks/generate_catalog.js
+++ b/tasks/generate_catalog.js
@@ -13,7 +13,8 @@ const viewster = require('../lib/view')
             keywords: 1,
             types: 1,
             categories: 1,
-            downloads: 1
+            downloads: 1,
+            deprecated: 1
         })
         const modules = things.map(function (t) {
             return {
@@ -25,7 +26,8 @@ const viewster = require('../lib/view')
                 keywords: t.keywords,
                 categories: t.categories,
                 url: 'https://flows.nodered.org/node/' + t._id,
-                downloads: t.downloads
+                downloads: t.downloads,
+                deprecated: t.deprecated || undefined
             }
         })
 

--- a/template/node.html
+++ b/template/node.html
@@ -12,6 +12,12 @@
             }
         </script>
         {{/message}}
+        {{#deprecated}}
+        <div class="deprecated-notice">
+            <h1>This module has been deprecated.</h1>
+            {{ #deprecatedMessage }}<code>{{ deprecatedMessage }}</code>{{/deprecatedMessage}}
+        </div>
+        {{/deprecated}}
         <h1 class="flow-title" style="margin-bottom: 10px;">{{ name }} <span class="flow-version">{{ versions.latest.version }}</span></h1>
         <p class="flow-description">{{ description }}</p>
         <p class="flowmeta flow-install">
@@ -77,6 +83,7 @@
                 {{#isAdmin}}
                     <button id="remove-button" type="submit" class="user-profile-action" style="background: none; color: #aa6767"><span id="remove-node-label">remove from library</span><img id="remove-node-loader" class="loader" src="/images/loader.gif" /></button>
                     <div id="remove-node-error" class="dialog-warning" style="position:relative"></div>
+                    <button id="deprecated-button" type="submit" class="user-profile-action" style="background: none; color: #aa6767"><span id="deprecate-node-label">deprecate module</span><img id="deprecate-node-loader" class="loader" src="/images/loader.gif" /></button>
                 {{/isAdmin}}
             </div>
             {{/sessionuser}}
@@ -155,6 +162,20 @@
         </form>
     </div>
 </div>
+
+<div class="dialog-shade dialog-fixed" id="edit-node-deprecation-shade">
+    <div class="dialog" id="edit-node-deprecation">
+        <form action="/node/{{_id}}/deprecate" method="POST">
+            <input name="_csrf" type="hidden" value="{{csrfToken}}">
+            <h4>Update deprecation details</h4>
+            <p><input id="node-deprecated-cb" type="checkbox" name="deprecated" {{#deprecated}}checked{{/deprecated}}><label for="node-deprecated-cb">Mark as deprecated</label></p>
+            <p><textarea name="message" id="message">{{ deprecatedMessage }}</textarea></p>
+            <div class="dialog-buttons">
+                <button type="button" onclick="return closeDialog();">Cancel</button> <button type="submit">Update</button>
+            </div>
+        </form>
+    </div>
+</div>
 {{/isAdmin}}
 
 
@@ -172,6 +193,11 @@
             $("body").css({height:"100%",overflow:"hidden"});
             e.preventDefault();
             $("#edit-node-category-shade").show();
+        });
+        $("#deprecated-button").click(function(e) {
+            $("body").css({height:"100%",overflow:"hidden"});
+            e.preventDefault();
+            $("#edit-node-deprecation-shade").show();
         });
         {{/isAdmin}}
 


### PR DESCRIPTION
Closes #117

Adds support for deprecating modules in the catalogue - as well as picking that status up from npm.

Admin users now have an option to edit deprecation settings:

<img width="838" alt="image" src="https://github.com/user-attachments/assets/c61cc1d5-28e2-4dbc-bb5e-cd97df3fbe28" />

Text message is optional.

If deprecated, the message is shown:

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/ef1b9995-760b-42ed-93e4-b88f155127b0" />

It will also pick this up from the npm registry if a module is marked as deprecated then updated - but the admin can override the setting via this ui.

The generated catalogue will then include the `deprecated` property as well. Support for reflecting that in the editor will come in 4.1 via https://github.com/node-red/node-red/pull/5134

